### PR TITLE
CMake: libvorbis doesn't export vorbisenc symbols on Win32

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -57,6 +57,10 @@ set(VORBISENC_SOURCES
     vorbisenc.c
 )
 
+if(WIN32)
+    list(APPEND VORBIS_SOURCES vorbisenc.c)
+endif()
+
 if(MSVC)
     list(APPEND VORBIS_SOURCES ../win32/vorbis.def)
     list(APPEND VORBISENC_SOURCES ../win32/vorbisenc.def)


### PR DESCRIPTION
The windows build defines a set of exported symbols with the `win32/vorbis.def` file.  The current cmake build however doesn't export all the symbols defined in that file.  By adding `vorbisenc.c` to the vorbis target when the build happens on a WIN32 platform the resulting .dll now links properly and exports all symbols declared in the .def file.
