### PR TITLE
doc/Makefile.am: Fix `clean` target

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -77,7 +77,6 @@ CLEANFILES = $(SPEC_TEX:%.tex=%.aux) \
 	     Vorbis_I_spec.lg  Vorbis_I_spec.log \
 	     Vorbis_I_spec.out Vorbis_I_spec.tmp \
 	     Vorbis_I_spec.toc Vorbis_I_spec.xref \
-	     Vorbis_I_spec*.png \
 	     zzVorbis_I_spec.ps
 DISTCLEANFILES = $(built_docs)
 


### PR DESCRIPTION
The `doc/Vorbis_I_spec*.png` files are checked into git, but were also
being incorrectly deleted during `make clean` because they were listed
in `CLEANFILES`.