### PR TITLE
Fix CMake error where vorbisenc and vorbis file didn't link to vorbis

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -80,8 +80,8 @@ if (NOT BUILD_FRAMEWORK)
     set_target_properties(vorbisfile PROPERTIES SOVERSION ${VORBISFILE_VERSION_INFO})
 
     target_link_libraries(vorbis ${OGG_LIBRARIES})
-    target_link_libraries(vorbisenc ${OGG_LIBRARIES})
-    target_link_libraries(vorbisfile ${OGG_LIBRARIES})
+    target_link_libraries(vorbisenc ${OGG_LIBRARIES} vorbis)
+    target_link_libraries(vorbisfile ${OGG_LIBRARIES} vorbis)
 
     install(FILES ${VORBIS_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/vorbis)
 


### PR DESCRIPTION
I was getting some linker errors in my project so I looked into the CMake files and saw this and this fixed it. Shouldn't be too controversial. 