### PR TITLE
Add CMake as optional buildsystem to AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,29 @@ platform:
 environment:
   matrix:
   - BUILD_SYSTEM: MSVC
+  - BUILD_SYSTEM: CMAKE
+
+matrix:
+  allow_failures:
+  - BUILD_SYSTEM: CMAKE
 
 install:
 - git clone -q https://github.com/xiph/ogg.git %APPVEYOR_BUILD_FOLDER%\..\libogg
 - if "%BUILD_SYSTEM%"=="MSVC" msbuild "%APPVEYOR_BUILD_FOLDER%\..\libogg\win32\VS2015\libogg_static.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
+- if "%BUILD_SYSTEM%"=="CMAKE" mkdir "%APPVEYOR_BUILD_FOLDER%\..\libogg\build"
+- if "%BUILD_SYSTEM%"=="CMAKE" pushd "%APPVEYOR_BUILD_FOLDER%\..\libogg\build"
+- if "%BUILD_SYSTEM%"=="CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" ..
+- if "%BUILD_SYSTEM%"=="CMAKE" cmake --build . --config "%CONFIGURATION%" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- if "%BUILD_SYSTEM%"=="CMAKE" popd
+
+before_build:
+- if "%BUILD_SYSTEM%" == "CMAKE" mkdir "%APPVEYOR_BUILD_FOLDER%\build"
+- if "%BUILD_SYSTEM%" == "CMAKE" pushd "%APPVEYOR_BUILD_FOLDER%\build"
+- if "%BUILD_SYSTEM%" == "CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" ..
+- if "%BUILD_SYSTEM%" == "CMAKE" popd
 
 build_script:
 - if "%BUILD_SYSTEM%"=="MSVC" msbuild "%APPVEYOR_BUILD_FOLDER%\win32\VS2010\vorbis_dynamic.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
+- if "%BUILD_SYSTEM%" == "CMAKE" pushd "%APPVEYOR_BUILD_FOLDER%\build"
+- if "%BUILD_SYSTEM%" == "CMAKE" cmake --build . --config "%CONFIGURATION%" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- if "%BUILD_SYSTEM%" == "CMAKE" popd

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,14 +19,14 @@ install:
 - if "%BUILD_SYSTEM%"=="MSVC" msbuild "%APPVEYOR_BUILD_FOLDER%\..\libogg\win32\VS2015\libogg_static.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
 - if "%BUILD_SYSTEM%"=="CMAKE" mkdir "%APPVEYOR_BUILD_FOLDER%\..\libogg\build"
 - if "%BUILD_SYSTEM%"=="CMAKE" pushd "%APPVEYOR_BUILD_FOLDER%\..\libogg\build"
-- if "%BUILD_SYSTEM%"=="CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" ..
+- if "%BUILD_SYSTEM%"=="CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" -DCMAKE_INSTALL_PREFIX="%APPVEYOR_BUILD_FOLDER%\..\libogg\install" ..
 - if "%BUILD_SYSTEM%"=="CMAKE" cmake --build . --config "%CONFIGURATION%" --target install -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - if "%BUILD_SYSTEM%"=="CMAKE" popd
 
 before_build:
 - if "%BUILD_SYSTEM%" == "CMAKE" mkdir "%APPVEYOR_BUILD_FOLDER%\build"
 - if "%BUILD_SYSTEM%" == "CMAKE" pushd "%APPVEYOR_BUILD_FOLDER%\build"
-- if "%BUILD_SYSTEM%" == "CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" -DOGG_ROOT="%PROGRAMFILES%\libogg" ..
+- if "%BUILD_SYSTEM%" == "CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" -DOGG_ROOT=%APPVEYOR_BUILD_FOLDER%\..\libogg\install ..
 - if "%BUILD_SYSTEM%" == "CMAKE" popd
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,5 @@ install:
 - git clone -q https://github.com/xiph/ogg.git %APPVEYOR_BUILD_FOLDER%\..\libogg
 - msbuild "%APPVEYOR_BUILD_FOLDER%\..\libogg\win32\VS2015\libogg_static.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
 
-build:
-  project: win32\VS2010\vorbis_dynamic.sln
-  parallel: true
-  verbosity: minimal
+build_script:
+- msbuild "%APPVEYOR_BUILD_FOLDER%\win32\VS2010\vorbis_dynamic.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,6 @@ environment:
   - BUILD_SYSTEM: MSVC
   - BUILD_SYSTEM: CMAKE
 
-matrix:
-  allow_failures:
-  - BUILD_SYSTEM: CMAKE
-
 install:
 - git clone -q https://github.com/xiph/ogg.git %APPVEYOR_BUILD_FOLDER%\..\libogg
 - if "%BUILD_SYSTEM%"=="MSVC" msbuild "%APPVEYOR_BUILD_FOLDER%\..\libogg\win32\VS2015\libogg_static.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
 - if "%BUILD_SYSTEM%"=="CMAKE" mkdir "%APPVEYOR_BUILD_FOLDER%\..\libogg\build"
 - if "%BUILD_SYSTEM%"=="CMAKE" pushd "%APPVEYOR_BUILD_FOLDER%\..\libogg\build"
 - if "%BUILD_SYSTEM%"=="CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" ..
-- if "%BUILD_SYSTEM%"=="CMAKE" cmake --build . --config "%CONFIGURATION%" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+- if "%BUILD_SYSTEM%"=="CMAKE" cmake --build . --config "%CONFIGURATION%" --target install -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - if "%BUILD_SYSTEM%"=="CMAKE" popd
 
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
 before_build:
 - if "%BUILD_SYSTEM%" == "CMAKE" mkdir "%APPVEYOR_BUILD_FOLDER%\build"
 - if "%BUILD_SYSTEM%" == "CMAKE" pushd "%APPVEYOR_BUILD_FOLDER%\build"
-- if "%BUILD_SYSTEM%" == "CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" ..
+- if "%BUILD_SYSTEM%" == "CMAKE" cmake -A "%PLATFORM%" -G "Visual Studio 14 2015" -DOGG_ROOT="%PROGRAMFILES%\libogg" ..
 - if "%BUILD_SYSTEM%" == "CMAKE" popd
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,13 @@ configuration:
 platform:
 - Win32
 
+environment:
+  matrix:
+  - BUILD_SYSTEM: MSVC
+
 install:
 - git clone -q https://github.com/xiph/ogg.git %APPVEYOR_BUILD_FOLDER%\..\libogg
-- msbuild "%APPVEYOR_BUILD_FOLDER%\..\libogg\win32\VS2015\libogg_static.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
+- if "%BUILD_SYSTEM%"=="MSVC" msbuild "%APPVEYOR_BUILD_FOLDER%\..\libogg\win32\VS2015\libogg_static.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
 
 build_script:
-- msbuild "%APPVEYOR_BUILD_FOLDER%\win32\VS2010\vorbis_dynamic.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%
+- if "%BUILD_SYSTEM%"=="MSVC" msbuild "%APPVEYOR_BUILD_FOLDER%\win32\VS2010\vorbis_dynamic.sln" /m /v:minimal /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /property:Configuration=%CONFIGURATION%;Platform=%PLATFORM%


### PR DESCRIPTION
This PR should enable building both Visual Studio and CMake on AppVeyor.  This should somewhat address #9 and enable pulling CMake relevant PRs with more confidence.

This is the first time using the AppVeyor matrix feature so this PR may or may not work in the first attempt.  Sorry for any future noise fixing this.