### PR TITLE
Add CMake as optional buildsystem to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
   - BUILD_SYSTEM=AUTOTOOLS
   - BUILD_SYSTEM=CMAKE
 
-matrix:
-  allow_failures:
-    - env: BUILD_SYSTEM=CMAKE
-
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,15 @@ compiler:
   - gcc
   - clang
 
+env:
+  - BUILD_SYSTEM=AUTOTOOLS
+
 addons:
   apt:
     packages:
     - libogg-dev
 
 script:
-  - ./autogen.sh
-  - ./configure
-  - make -j2 V=1 distcheck
+  - if [[ "$BUILD_SYSTEM" == "AUTOTOOLS" ]] ; then ./autogen.sh ; fi
+  - if [[ "$BUILD_SYSTEM" == "AUTOTOOLS" ]] ; then ./configure ; fi
+  - if [[ "$BUILD_SYSTEM" == "AUTOTOOLS" ]] ; then make -j2 V=1 distcheck ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ compiler:
 
 env:
   - BUILD_SYSTEM=AUTOTOOLS
+  - BUILD_SYSTEM=CMAKE
+
+matrix:
+  allow_failures:
+    - env: BUILD_SYSTEM=CMAKE
 
 addons:
   apt:
@@ -16,3 +21,8 @@ script:
   - if [[ "$BUILD_SYSTEM" == "AUTOTOOLS" ]] ; then ./autogen.sh ; fi
   - if [[ "$BUILD_SYSTEM" == "AUTOTOOLS" ]] ; then ./configure ; fi
   - if [[ "$BUILD_SYSTEM" == "AUTOTOOLS" ]] ; then make -j2 V=1 distcheck ; fi
+  - if [[ "$BUILD_SYSTEM" == "CMAKE" ]] ; then mkdir build ; fi
+  - if [[ "$BUILD_SYSTEM" == "CMAKE" ]] ; then pushd build ; fi
+  - if [[ "$BUILD_SYSTEM" == "CMAKE" ]] ; then cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release .. ; fi
+  - if [[ "$BUILD_SYSTEM" == "CMAKE" ]] ; then cmake --build . ; fi
+  - if [[ "$BUILD_SYSTEM" == "CMAKE" ]] ; then popd ; fi


### PR DESCRIPTION
This PR should enable building both Autotools and CMake on Travis-CI. This should mostly address #9 and enable pulling CMake relevant PRs with more confidence.

This is the first time using the Travis-CI matrix feature so this PR may or may not work in the first attempt. Sorry for any future noise fixing this.