### PR TITLE
Fix reading maximum, nominal, minimum bitrate in _vorbis_unpack_info().

### DIFF
--- a/lib/info.c
+++ b/lib/info.c
@@ -211,9 +211,9 @@ static int _vorbis_unpack_info(vorbis_info *vi,oggpack_buffer *opb){
   vi->channels=oggpack_read(opb,8);
   vi->rate=oggpack_read(opb,32);
 
-  vi->bitrate_upper=oggpack_read(opb,32);
-  vi->bitrate_nominal=oggpack_read(opb,32);
-  vi->bitrate_lower=oggpack_read(opb,32);
+  vi->bitrate_upper=(ogg_int32_t)oggpack_read(opb,32);
+  vi->bitrate_nominal=(ogg_int32_t)oggpack_read(opb,32);
+  vi->bitrate_lower=(ogg_int32_t)oggpack_read(opb,32);
 
   ci->blocksizes[0]=1<<oggpack_read(opb,4);
   ci->blocksizes[1]=1<<oggpack_read(opb,4);


### PR DESCRIPTION
https://xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-630004.2.2 specifies
these fields as 32bit signed. oggpack_read(opb,32), which is used to
read these fields, returns 32 bits stored in a long. On architectures
where long is 64bit, this results in a positive value being returned.
This value is then stored in struct vorbis_info in bitrate_upper,
bitrate_nominal and bitrate_lower, also as long. ogginfo relies on
these values in order to display the respective header fields and thus
misrepresented the stored value -1 (which has the intended meaning of
"bitrate not set") as 2**32-1 on architectures where long is 64bit.

Explicitly cast the return value of oggpack_read() to a signed 32bit
integer type.

A nominal bitrate value of -1 is valid as per specification, and is
written by libvorbis for VBR files with samplerate >= 50000Hz.