### PR TITLE
mapping0.c (mapping0_unpack): kill a useless memset()

### DIFF
--- a/lib/mapping0.c
+++ b/lib/mapping0.c
@@ -92,7 +92,6 @@ static vorbis_info_mapping *mapping0_unpack(vorbis_info *vi,oggpack_buffer *opb)
   int i,b;
   vorbis_info_mapping0 *info=_ogg_calloc(1,sizeof(*info));
   codec_setup_info     *ci=vi->codec_setup;
-  memset(info,0,sizeof(*info));
   if(vi->channels<=0)goto err_out;
 
   b=oggpack_read(opb,1);


### PR DESCRIPTION
info is allocated with calloc() already.