### PR TITLE
CVE-2017-14633: Don't allow for more than 256 channels

### DIFF
--- a/lib/info.c
+++ b/lib/info.c
@@ -588,7 +588,7 @@ int vorbis_analysis_headerout(vorbis_dsp_state *v,
   oggpack_buffer opb;
   private_state *b=v->backend_state;
 
-  if(!b||vi->channels<=0){
+  if(!b||vi->channels<=0||vi->channels>256){
     ret=OV_EFAULT;
     goto err_out;
   }

--- a/lib/info.c
+++ b/lib/info.c
@@ -589,6 +589,7 @@ int vorbis_analysis_headerout(vorbis_dsp_state *v,
   private_state *b=v->backend_state;
 
   if(!b||vi->channels<=0||vi->channels>256){
+    b = NULL;
     ret=OV_EFAULT;
     goto err_out;
   }


### PR DESCRIPTION
Otherwise

 for(i=0;i<vi->channels;i++){
      /* the encoder setup assumes that all the modes used by any
         specific bitrate tweaking use the same floor */
      int submap=info->chmuxlist[i];

overreads later in mapping0_forward since chmuxlist is a fixed array of
256 elements max.

This fixes https://gitlab.xiph.org/xiph/vorbis/issues/2329 for me but I don't know much about vorbis so I might be wrong.