### PR TITLE
Fixed error in Vorbis I specification for limiting residue vector size

### DIFF
--- a/doc/08-residue.tex
+++ b/doc/08-residue.tex
@@ -269,8 +269,8 @@ process.
   1) [actual\_size] = current blocksize/2;
   2) if residue encoding is format 2
        3) [actual\_size] = [actual\_size] * [ch];
-  4) [limit\_residue\_begin] = maximum of ([residue\_begin],[actual\_size]);
-  5) [limit\_residue\_end] = maximum of ([residue\_end],[actual\_size]);
+  4) [limit\_residue\_begin] = minimum of ([residue\_begin],[actual\_size]);
+  5) [limit\_residue\_end] = minimum of ([residue\_end],[actual\_size]);
 \end{programlisting}
 
 The following convenience values are conceptually useful to clarifying

--- a/doc/Vorbis_I_spec.html
+++ b/doc/Vorbis_I_spec.html
@@ -9737,7 +9737,7 @@ class="cmtt-8">&#x00A0;</span><span
 class="cmtt-8">&#x00A0;4)</span><span 
 class="cmtt-8">&#x00A0;[limit\_residue\_begin]</span><span 
 class="cmtt-8">&#x00A0;=</span><span 
-class="cmtt-8">&#x00A0;maximum</span><span 
+class="cmtt-8">&#x00A0;minimum</span><span 
 class="cmtt-8">&#x00A0;of</span><span 
 class="cmtt-8">&#x00A0;([residue\_begin],[actual\_size]);</span>
 <br class="fancyvrb" /><a 
@@ -9749,7 +9749,7 @@ class="cmtt-8">&#x00A0;</span><span
 class="cmtt-8">&#x00A0;5)</span><span 
 class="cmtt-8">&#x00A0;[limit\_residue\_end]</span><span 
 class="cmtt-8">&#x00A0;=</span><span 
-class="cmtt-8">&#x00A0;maximum</span><span 
+class="cmtt-8">&#x00A0;minimum</span><span 
 class="cmtt-8">&#x00A0;of</span><span 
 class="cmtt-8">&#x00A0;([residue\_end],[actual\_size]);</span></div>
 <!--l. 277--><p class="noindent" >The following convenience values are conceptually useful to clarifying the decode process:


### PR DESCRIPTION
The minimum between the encoded residue boundaries and actual block size
needs to be used, otherwise it pushes the boundaries to the edge of the
actual blocksize or beyond.