### PR TITLE
Allow Vorbis Read Size to be set by user

### DIFF
--- a/include/vorbis/vorbisfile.h
+++ b/include/vorbis/vorbisfile.h
@@ -143,6 +143,9 @@ typedef struct OggVorbis_File {
 
   ov_callbacks callbacks;
 
+  /* The read size of the vorbis file */
+  int             read_size;
+
 } OggVorbis_File;
 
 
@@ -185,6 +188,7 @@ extern double ov_time_tell(OggVorbis_File *vf);
 
 extern vorbis_info *ov_info(OggVorbis_File *vf,int link);
 extern vorbis_comment *ov_comment(OggVorbis_File *vf,int link);
+extern void ov_set_read_size(OggVorbis_File *vf,int read_size);
 
 extern long ov_read_float(OggVorbis_File *vf,float ***pcm_channels,int samples,
                           int *bitstream);

--- a/lib/vorbisfile.c
+++ b/lib/vorbisfile.c
@@ -68,8 +68,8 @@ static long _get_data(OggVorbis_File *vf){
   errno=0;
   if(!(vf->callbacks.read_func))return(-1);
   if(vf->datasource){
-    char *buffer=ogg_sync_buffer(&vf->oy,READSIZE);
-    long bytes=(vf->callbacks.read_func)(buffer,1,READSIZE,vf->datasource);
+    char *buffer=ogg_sync_buffer(&vf->oy,vf->read_size);
+    long bytes=(vf->callbacks.read_func)(buffer,1,vf->read_size,vf->datasource);
     if(bytes>0)ogg_sync_wrote(&vf->oy,bytes);
     if(bytes==0 && errno)return(-1);
     return(bytes);
@@ -884,6 +884,7 @@ static int _ov_open1(void *f,OggVorbis_File *vf,const char *initial,
   memset(vf,0,sizeof(*vf));
   vf->datasource=f;
   vf->callbacks = callbacks;
+  vf->read_size = READSIZE;
 
   /* init the framing state */
   ogg_sync_init(&vf->oy);
@@ -1909,6 +1910,10 @@ vorbis_comment *ov_comment(OggVorbis_File *vf,int link){
   }else{
     return vf->vc;
   }
+}
+
+void ov_set_read_size(OggVorbis_File *vf,int read_size) {
+  vf->read_size = read_size;
 }
 
 static int host_is_big_endian() {


### PR DESCRIPTION
* Hooking up Vorbis read callbacks to an HTTP data
provider currently yields a lot of overhead due to
many read requests at 2kB
* Allowing the user to set the vorbis read size
lets backend reads become more efficient by
reading greater chunks at any given time