### PR TITLE
Check for SSE2-math before using it.

### DIFF
--- a/lib/os.h
+++ b/lib/os.h
@@ -80,7 +80,7 @@ void *_alloca(size_t size);
 
 
 /* Special i386 GCC implementation */
-#if defined(__i386__) && defined(__GNUC__) && !defined(__BEOS__)
+#if defined(__i386__) && defined(__GNUC__) && !defined(__BEOS__) && !defined(__SSE2_MATH__)
 #  define VORBIS_FPU_CONTROL
 /* both GCC and MSVC are kinda stupid about rounding/casting to int.
    Because of encapsulation constraints (GCC can't see inside the asm
@@ -147,7 +147,7 @@ static __inline void vorbis_fpu_restore(vorbis_fpu_control fpu){
 
 /* Optimized code path for x86_64 builds. Uses SSE2 intrinsics. This can be
    done safely because all x86_64 CPUs supports SSE2. */
-#if (defined(_MSC_VER) && defined(_WIN64)) || (defined(__GNUC__) && defined (__x86_64__))
+#if (defined(_MSC_VER) && defined(_WIN64)) || (defined(__GNUC__) && defined (__SSE2_MATH__))
 #  define VORBIS_FPU_CONTROL
 
 typedef ogg_int16_t vorbis_fpu_control;


### PR DESCRIPTION
We should check if it's actually allowed to use SSE2-math. Also this patch enables SSE2 on i686 targets if it's enabled during compilation.
To allow SSE2-math on i686 you should compile vorbis with *-mfpmath=sse* (and *-march* of course) or **gcc** itself with *--with-fpmath=sse* parameter. On x86_64 `__SSE2_MATH__` defined by default unless you disable it with *-mfpmath=387*.
So basically this patch mostly matters for people who compile for i686 with explicitly enabled SSE2-math support.

You can play with the `__SSE2_MATH__` define here https://godbolt.org/z/3xwuft.