### PR TITLE
cmake: install headers into lower case include path instead

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -106,7 +106,7 @@ if (NOT BUILD_FRAMEWORK)
     target_link_libraries(vorbisenc PUBLIC vorbis)
     target_link_libraries(vorbisfile PUBLIC vorbis)
 
-    install(FILES ${VORBIS_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/Vorbis)
+    install(FILES ${VORBIS_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/vorbis)
 
     install(TARGETS vorbis vorbisenc vorbisfile
         EXPORT VorbisTargets


### PR DESCRIPTION
The majority of software includes the vorbis headers from a lower case directory thus fails to find it if its upper case on case-sensitive file systems, this commit resolves that.

(That AppVeyor fail seems unrelated)
this fix is also in #63, which got created after i made this PR