### PR TITLE
Link test with -lm to fix build problem with ld --no-add-needed

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -10,7 +10,7 @@ check: $(check_PROGRAMS)
 AM_CPPFLAGS = -I$(top_srcdir)/include @OGG_CFLAGS@
 
 test_SOURCES = util.c util.h write_read.c write_read.h test.c
-test_LDADD = ../lib/libvorbisenc.la ../lib/libvorbis.la @OGG_LIBS@ @VORBIS_LIBS@
+test_LDADD = ../lib/libvorbisenc.la ../lib/libvorbis.la @OGG_LIBS@ @VORBIS_LIBS@ -lm
 
 debug:
 	$(MAKE) check CFLAGS="@DEBUG@"


### PR DESCRIPTION
0001-Fix-build-failure-with-DSO-link-changes.patch from Debian, see
http://bugs.debian.org/604797 .