### PR TITLE
Fix pkgconfig creation with cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,9 @@ message(STATUS "Configuring ${PROJECT_NAME} ${PROJECT_VERSION}")
 # Find math library
 
 check_library_exists(m floor "" HAVE_LIBM)
+if(HAVE_LIBM)
+    set(VORBIS_LIBS "-lm")
+endif()
 
 # Find ogg dependency
 find_package(Ogg REQUIRED)


### PR DESCRIPTION
The cmake build script was not setting a VORBIS_LIBS variable that is used to update pkg-config files. This results in linking errors in downstream projects due to missing dependencies (in this case libm).

This patch just updates the cmake script to behave the same configure does currently.