### PR TITLE
Add library name to def files

### DIFF
--- a/win32/vorbis.def
+++ b/win32/vorbis.def
@@ -1,6 +1,6 @@
 ; vorbis.def
 ; 
-LIBRARY
+LIBRARY vorbis
 EXPORTS
 _floor_P
 _mapping_P

--- a/win32/vorbisenc.def
+++ b/win32/vorbisenc.def
@@ -1,6 +1,6 @@
 ; vorbisenc.def
 ;
-LIBRARY
+LIBRARY vorbisenc
 
 EXPORTS
 vorbis_encode_init

--- a/win32/vorbisfile.def
+++ b/win32/vorbisfile.def
@@ -1,6 +1,6 @@
 ; vorbisfile.def
 ;
-LIBRARY
+LIBRARY vorbisfile
 EXPORTS
 ov_clear
 ov_open


### PR DESCRIPTION
I was getting this error when cross compiling using MinGW under Debian.

`/usr/bin/x86_64-w64-mingw32-ld: ../../win32/vorbis.def:3: syntax error`
`/usr/bin/x86_64-w64-mingw32-ld:../../win32/vorbis.def: file format not recognized; treating as linker script`
`/usr/bin/x86_64-w64-mingw32-ld:../../win32/vorbis.def:2: syntax error`
`collect2: error: ld returned 1 exit status`

According to the Microsoft C++ Docs, the the name of the DLL must be after LIBRARY statement.
[https://docs.microsoft.com/en-us/cpp/build/exporting-from-a-dll-using-def-files](url)