### PR TITLE
lib/os.h, test/util.c: define _USE_MATH_DEFINES for windows builds

### DIFF
--- a/lib/os.h
+++ b/lib/os.h
@@ -20,6 +20,9 @@
 #include "config.h"
 #endif
 
+#ifdef _WIN32
+#define _USE_MATH_DEFINES 1
+#endif
 #include <math.h>
 #include <ogg/os_types.h>
 

--- a/test/util.c
+++ b/test/util.c
@@ -14,6 +14,10 @@
 
  ********************************************************************/
 
+#ifdef _WIN32
+#define _USE_MATH_DEFINES 1
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>


### PR DESCRIPTION
it is required to access the M_PI macro.