### PR TITLE
fix of implicit type conversion.

### DIFF
--- a/lib/bitrate.c
+++ b/lib/bitrate.c
@@ -42,7 +42,7 @@ void vorbis_bitrate_init(vorbis_info *vi,bitrate_manager_state *bm){
     bm->min_bitsper= rint(1.*bi->min_rate*halfsamples/ratesamples);
     bm->max_bitsper= rint(1.*bi->max_rate*halfsamples/ratesamples);
 
-    bm->avgfloat=PACKETBLOBS/2;
+    bm->avgfloat=(double)(PACKETBLOBS)/2;
 
     /* not a necessary fix, but one that leads to a more balanced
        typical initialization */

--- a/lib/envelope.c
+++ b/lib/envelope.c
@@ -106,7 +106,7 @@ static int _ve_amp(envelope_lookup *ve,
   /* stretch is used to gradually lengthen the number of windows
      considered prevoius-to-potential-trigger */
   int stretch=max(VE_MINSTRETCH,ve->stretch/2);
-  float penalty=gi->stretch_penalty-(ve->stretch/2-VE_MINSTRETCH);
+  float penalty=gi->stretch_penalty-((float)(ve->stretch)/2-VE_MINSTRETCH);
   if(penalty<0.f)penalty=0.f;
   if(penalty>gi->stretch_penalty)penalty=gi->stretch_penalty;
 

--- a/lib/floor1.c
+++ b/lib/floor1.c
@@ -560,7 +560,7 @@ static int inspect_error(int x0,int x1,int y0,int y1,const float *mask,
 
   if(info->maxover*info->maxover/n>info->maxerr)return(0);
   if(info->maxunder*info->maxunder/n>info->maxerr)return(0);
-  if(mse/n>info->maxerr)return(1);
+  if((float)(mse)/n>info->maxerr)return(1);
   return(0);
 }
 


### PR DESCRIPTION
in casting used in your code, first the result of division is converted to an integer type, with the loss of the fractional part, and then the integer is converted to a floating point type. I think this can be simply fixed.