### PR TITLE
Fix tests run with make check when using alternative allocators.

### DIFF
--- a/lib/sharedbook.c
+++ b/lib/sharedbook.c
@@ -581,7 +581,7 @@ void run_test(static_codebook *b,float *comp){
       exit(1);
     }
   }
-  free(out);
+  _ogg_free(out);
 }
 
 int main(){


### PR DESCRIPTION
The call to `free` in line [584 of sharedbook.c](https://github.com/xiph/vorbis/blob/master/lib/sharedbook.c#L584) mismatches the `_ogg_calloc` call used to allocated that data in line [216](https://github.com/xiph/vorbis/blob/master/lib/sharedbook.c#L216).

This causes `make check` to fail when alternative allocators are used, e.g. the `xmm_malloc` family of allocators used with the Lancer optimizations.