### PR TITLE
CMake: Link libm to test binaries if available

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_executable(vorbis_test util.c util.h write_read.c write_read.h test.c)
-target_link_libraries(vorbis_test PRIVATE Vorbis::vorbisenc)
+target_link_libraries(vorbis_test PRIVATE Vorbis::vorbisenc $<$<BOOL:${HAVE_LIBM}>:m>)
 add_test(NAME vorbis_test COMMAND vorbis_test)


### PR DESCRIPTION
If libm is available link it to test binaries which will otherwise fail to compile
Tested on FreeBSD 13-STABLE

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>