### PR TITLE
Don't export vorbisenc functions from vorbis.dll on Windows

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -58,10 +58,6 @@ set(VORBISENC_SOURCES
 )
 
 if(WIN32)
-    list(APPEND VORBIS_SOURCES vorbisenc.c)
-endif()
-
-if(WIN32)
     list(APPEND VORBIS_SOURCES ../win32/vorbis.def)
     list(APPEND VORBISENC_SOURCES ../win32/vorbisenc.def)
     list(APPEND VORBISFILE_SOURCES ../win32/vorbisfile.def)

--- a/win32/vorbis.def
+++ b/win32/vorbis.def
@@ -48,11 +48,4 @@ vorbis_synthesis_idheader
 ;
 vorbis_window
 ;_analysis_output_always
-vorbis_encode_init
-vorbis_encode_setup_managed
-vorbis_encode_setup_vbr
-vorbis_encode_init_vbr
-vorbis_encode_setup_init
-vorbis_encode_ctl
-;
 vorbis_version_string


### PR DESCRIPTION
This matches the behaviour on other platforms, as well as the behaviour with MinGW autotools builds, and reduces the size of the resulting DLL significantly.

This replaces PR #64.
