### PR TITLE
Set both VERSION and SOVERSION for cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,8 @@ set(PROJECT_VERSION_MINOR ${CMAKE_MATCH_2})
 set(PROJECT_VERSION_PATCH ${CMAKE_MATCH_3})
 set(PROJECT_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 
-# Helper function to get version-info
-function(get_version_info result current_var_name age_var_name revision_var_name)
+# Helper function to get library versions
+function(get_lib_versions version_result soversion_result current_var_name age_var_name revision_var_name)
     string(REGEX MATCH "${current_var_name}=([0-9]*)" DUMMY ${CONFIGURE_AC_CONTENTS})
     set(VERSION_INFO_CURRENT ${CMAKE_MATCH_1})
 
@@ -42,7 +42,8 @@ function(get_version_info result current_var_name age_var_name revision_var_name
 
     math(EXPR VERSION_INFO_CURRENT_MINUS_AGE "${VERSION_INFO_CURRENT} - ${VERSION_INFO_AGE}")
 
-    set(${result} "${VERSION_INFO_CURRENT_MINUS_AGE}.${VERSION_INFO_AGE}.${VERSION_INFO_REVISION}" PARENT_SCOPE)
+    set(${version_result} "${VERSION_INFO_CURRENT_MINUS_AGE}.${VERSION_INFO_AGE}.${VERSION_INFO_REVISION}" PARENT_SCOPE)
+    set(${soversion_result} "${VERSION_INFO_CURRENT_MINUS_AGE}" PARENT_SCOPE)
 endfunction()
 
 # Helper function to configure pkg-config files

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -82,12 +82,12 @@ if (NOT BUILD_FRAMEWORK)
     add_library(Vorbis::vorbisenc ALIAS vorbisenc)
     add_library(Vorbis::vorbisfile ALIAS vorbisfile)
 
-    get_version_info(VORBIS_VERSION_INFO "V_LIB_CURRENT" "V_LIB_AGE" "V_LIB_REVISION")
-    set_target_properties(vorbis PROPERTIES SOVERSION ${VORBIS_VERSION_INFO})
-    get_version_info(VORBISENC_VERSION_INFO "VE_LIB_CURRENT" "VE_LIB_AGE" "VE_LIB_REVISION")
-    set_target_properties(vorbisenc PROPERTIES SOVERSION ${VORBISENC_VERSION_INFO})
-    get_version_info(VORBISFILE_VERSION_INFO "VF_LIB_CURRENT" "VF_LIB_AGE" "VF_LIB_REVISION")
-    set_target_properties(vorbisfile PROPERTIES SOVERSION ${VORBISFILE_VERSION_INFO})
+    get_lib_versions(VORBIS_VERSION VORBIS_SOVERSION "V_LIB_CURRENT" "V_LIB_AGE" "V_LIB_REVISION")
+    set_target_properties(vorbis PROPERTIES VERSION ${VORBIS_VERSION} SOVERSION ${VORBIS_SOVERSION})
+    get_lib_versions(VORBISENC_VERSION VORBISENC_SOVERSION "VE_LIB_CURRENT" "VE_LIB_AGE" "VE_LIB_REVISION")
+    set_target_properties(vorbisenc PROPERTIES VERSION ${VORBISENC_VERSION} SOVERSION ${VORBISENC_SOVERSION})
+    get_lib_versions(VORBISFILE_VERSION VORBISFILE_SOVERSION "VF_LIB_CURRENT" "VF_LIB_AGE" "VF_LIB_REVISION")
+    set_target_properties(vorbisfile PROPERTIES VERSION ${VORBISFILE_VERSION} SOVERSION ${VORBISFILE_SOVERSION})
 
     target_include_directories(vorbis
         PUBLIC


### PR DESCRIPTION
When building with cmake you get a different set of library links compared to when building with autotools.

For cmake builds you don't get libvorbis*.so.X which means that applications trying to load these libraries dynamically will fail.