### PR TITLE
Fix -Wmisleading-indentation warning.

### DIFF
--- a/lib/block.c
+++ b/lib/block.c
@@ -392,9 +392,9 @@ float **vorbis_analysis_buffer(vorbis_dsp_state *v, int vals){
   private_state *b=v->backend_state;
 
   /* free header, header1, header2 */
-  if(b->header)_ogg_free(b->header);b->header=NULL;
-  if(b->header1)_ogg_free(b->header1);b->header1=NULL;
-  if(b->header2)_ogg_free(b->header2);b->header2=NULL;
+  if(b->header){_ogg_free(b->header);b->header=NULL;}
+  if(b->header1){_ogg_free(b->header1);b->header1=NULL;}
+  if(b->header2){_ogg_free(b->header2);b->header2=NULL;}
 
   /* Do we have enough storage space for the requested buffer? If not,
      expand the PCM (and envelope) storage */


### PR DESCRIPTION
Fixes <https://gitlab.xiph.org/xiph/vorbis/-/issues/2349>.