### PR TITLE
Fix -Wstrict-prototypes warning.

### DIFF
--- a/lib/vorbisfile.c
+++ b/lib/vorbisfile.c
@@ -1910,7 +1910,7 @@ vorbis_comment *ov_comment(OggVorbis_File *vf,int link){
   }
 }
 
-static int host_is_big_endian() {
+static int host_is_big_endian(void) {
   ogg_int32_t pattern = 0xfeedface; /* deadbeef */
   unsigned char *bytewise = (unsigned char *)&pattern;
   if (bytewise[0] == 0xfe) return 1;


### PR DESCRIPTION
Fixes <https://gitlab.xiph.org/xiph/vorbis/-/issues/2350>.