### PR TITLE
Fix compilation on current MacOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,9 +202,9 @@ else
 		CFLAGS="-O3 -Wall -Wextra -ffast-math -D__NO_MATH_INLINES -fsigned-char $sparc_cpu"
 		PROFILE="-pg -g -O3 -D__NO_MATH_INLINES -fsigned-char $sparc_cpu" ;;
 	*-*-darwin*)
-		DEBUG="-DDARWIN -fno-common -force_cpusubtype_ALL -Wall -g -O0 -fsigned-char"
-		CFLAGS="-DDARWIN -fno-common -force_cpusubtype_ALL -Wall -g -O3 -ffast-math -fsigned-char"
-		PROFILE="-DDARWIN -fno-common -force_cpusubtype_ALL -Wall -g -pg -O3 -ffast-math -fsigned-char";;
+		DEBUG="-DDARWIN -fno-common -Wall -g -O0 -fsigned-char"
+		CFLAGS="-DDARWIN -fno-common -Wall -g -O3 -ffast-math -fsigned-char"
+		PROFILE="-DDARWIN -fno-common -Wall -g -pg -O3 -ffast-math -fsigned-char";;
 	*-*-os2*)
 		# Use -W instead of -Wextra because gcc on OS/2 is an old version.
 		DEBUG="-g -Wall -W -D_REENTRANT -D__NO_MATH_INLINES -fsigned-char"


### PR DESCRIPTION
The "-force_cpusubtype_ALL" flag, which configure adds unconditionally when building for Darwin, is apparently not supported by current Apple compilers.

I don't use MacOS, so I have no way to test this myself.

However, it appears that in GitHub workflows targetting "macos-12", the flag is supported, whereas in GitHub workflows targetting "macos-13" or "macos-14" the flag is not supported, and results in the error
```
ld: unknown options: -force_cpusubtype_ALL
```

The patch that introduced this flag doesn't provide any details: https://lists.xiph.org/pipermail/vorbis-dev/2001-January/002993.html

(Fixes issue #107)
