### PR TITLE
autotools, darwin: restrict -force_cpusubtype_ALL switch to powerpc only

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,10 +201,14 @@ else
 		DEBUG="-g -Wall -Wextra -D__NO_MATH_INLINES -fsigned-char $sparc_cpu"
 		CFLAGS="-O3 -Wall -Wextra -ffast-math -D__NO_MATH_INLINES -fsigned-char $sparc_cpu"
 		PROFILE="-pg -g -O3 -D__NO_MATH_INLINES -fsigned-char $sparc_cpu" ;;
-	*-*-darwin*)
+	powerpc-*-darwin*)
 		DEBUG="-DDARWIN -fno-common -force_cpusubtype_ALL -Wall -g -O0 -fsigned-char"
 		CFLAGS="-DDARWIN -fno-common -force_cpusubtype_ALL -Wall -g -O3 -ffast-math -fsigned-char"
 		PROFILE="-DDARWIN -fno-common -force_cpusubtype_ALL -Wall -g -pg -O3 -ffast-math -fsigned-char";;
+	*-*-darwin*)
+		DEBUG="-DDARWIN -fno-common -Wall -g -O0 -fsigned-char"
+		CFLAGS="-DDARWIN -fno-common -Wall -g -O3 -ffast-math -fsigned-char"
+		PROFILE="-DDARWIN -fno-common -Wall -g -pg -O3 -ffast-math -fsigned-char";;
 	*-*-os2*)
 		# Use -W instead of -Wextra because gcc on OS/2 is an old version.
 		DEBUG="-g -Wall -W -D_REENTRANT -D__NO_MATH_INLINES -fsigned-char"


### PR DESCRIPTION
Fixes: https://github.com/xiph/vorbis/issues/107
Fixes: https://github.com/xiph/vorbis/pull/108
(See also: https://github.com/mkxp-z/mkxp-z/pull/200)
