### PR TITLE
Remove unused variable y2b from fit_line

### DIFF
--- a/lib/floor1.c
+++ b/lib/floor1.c
@@ -455,7 +455,7 @@ static int accumulate_fit(const float *flr,const float *mdct,
 
 static int fit_line(lsfit_acc *a,int fits,int *y0,int *y1,
                     vorbis_info_floor1 *info){
-  double xb=0,yb=0,x2b=0,y2b=0,xyb=0,bn=0;
+  double xb=0,yb=0,x2b=0,xyb=0,bn=0;
   int i;
   int x0=a[0].x0;
   int x1=a[fits-1].x1;
@@ -466,7 +466,6 @@ static int fit_line(lsfit_acc *a,int fits,int *y0,int *y1,
     xb+=a[i].xb + a[i].xa * weight;
     yb+=a[i].yb + a[i].ya * weight;
     x2b+=a[i].x2b + a[i].x2a * weight;
-    y2b+=a[i].y2b + a[i].y2a * weight;
     xyb+=a[i].xyb + a[i].xya * weight;
     bn+=a[i].bn + a[i].an * weight;
   }
@@ -475,7 +474,6 @@ static int fit_line(lsfit_acc *a,int fits,int *y0,int *y1,
     xb+=   x0;
     yb+=  *y0;
     x2b+=  x0 *  x0;
-    y2b+= *y0 * *y0;
     xyb+= *y0 *  x0;
     bn++;
   }
@@ -484,7 +482,6 @@ static int fit_line(lsfit_acc *a,int fits,int *y0,int *y1,
     xb+=   x1;
     yb+=  *y1;
     x2b+=  x1 *  x1;
-    y2b+= *y1 * *y1;
     xyb+= *y1 *  x1;
     bn++;
   }


### PR DESCRIPTION
Found via clang warning:

````
warning: variable 'y2b' set but not used [-Wunused-but-set-variable]
  458 |   double xb=0,yb=0,x2b=0,y2b=0,xyb=0,bn=0;
```