### PR TITLE
Fix CMake BUILD_FRAMEWORK source include dir and 'make install'.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -164,5 +164,22 @@ else()
         PUBLIC_HEADER "${VORBIS_PUBLIC_HEADERS}"
         OUTPUT_NAME Vorbis
     )
+
+    target_include_directories(vorbis
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+
     target_link_libraries(vorbis ${OGG_LIBRARIES})
+
+    install(TARGETS vorbis
+        EXPORT VorbisTargets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        FRAMEWORK DESTINATION ${CMAKE_INSTALL_PREFIX}
+    )
 endif()


### PR DESCRIPTION
+ The CMakeFiles.txt did not specify a source include directory for BUILD_FRAMEWORK builds, causing builds to fail due to missing headers when using a build directory other than the source directory.
+ The CMakeFiles.txt was missing an install command for BUILD_FRAMEWORK builds, so `make install` would fail to actually install the framework. This patch specifies the framework install destination as CMAKE_INSTALL_PREFIX to match libogg.

Be advised I'm not an experienced CMake user and this is a copypaste job, so there is almost certainly a cleaner way to do this.

To reproduce the issues this resolves, do the following from the Vorbis repository root on macOS:
```sh
mkdir -p BUILD/_install
cd BUILD
cmake -B . -S .. -D BUILD_FRAMEWORK=1 -D BUILD_TESTING=0 \
    -D CMAKE_FRAMEWORK_PATH=[location of Ogg.framework] \
    -D CMAKE_INSTALL_PREFIX="$(pwd)/_install"

# Will fail without this patch due to a missing header.
# For Vorbis 1.3.7, the failure was mdct.c due to missing vorbis/codec.h
# For Git, the failure is vorbisenc.c due to missing modes/floor_all.h
# This patch resolves either.
make

# Will not install Vorbis.framework to CMAKE_INSTALL_PREFIX without this patch.
make install
```