### PR TITLE
small doc fixes

### DIFF
--- a/doc/libvorbis/vorbis_analysis_blockout.html
+++ b/doc/libvorbis/vorbis_analysis_blockout.html
@@ -49,8 +49,8 @@ returned data.
 
 <h3>Return Values</h3>
 <ul>
-<li>1 for success when more blocks are available.</li>
-<li>0 for success when this is the last block available from the current input.</li>
+<li>1 for success, with a block returned.</li>
+<li>0 if the last block available from the current input has already been returned.</li>
 <li>negative values for failure:
 <ul>
 <li>OV_EINVAL - Invalid parameters.</li> 

--- a/doc/libvorbis/vorbis_analysis_buffer.html
+++ b/doc/libvorbis/vorbis_analysis_buffer.html
@@ -21,7 +21,7 @@
 encoder for compression.</p>
 
 <p>The Vorbis encoder expects the caller to write audio data as
-non-interleaved floating point samples into its internal buffers.
+non-interleaved floating point samples in the range [-1,1) into its internal buffers.
 </p>
 <p>
 The general procedure is to call this function with the number of samples

--- a/doc/libvorbis/vorbis_bitrate_flushpacket.html
+++ b/doc/libvorbis/vorbis_bitrate_flushpacket.html
@@ -50,8 +50,8 @@ extern int      vorbis_bitrate_flushpacket(vorbis_dsp_state *vd,
 
 <h3>Return Values</h3>
 <ul>
-<li>1 for success when more packets are available.
-<li>0 for success when this is the last packet available from the current input.</li>
+<li>1 for success, with a packet returned.</li>
+<li>0 if the last packet available from the current input has already been returned.</li>
 <li>negative values for failure:
 <ul>
 <li>OV_EINVAL - Invalid parameters.</li> 


### PR DESCRIPTION
I was confused by a few things when adding Vorbis support to my [Klipspringer audio platform](https://klipspringer.avadeaux.net/). I tried to do the encoding implementation based on the encoding workflow on the [overview page](https://xiph.org/vorbis/doc/libvorbis/overview.html), but I couldn’t get it to work until I switched to following [encoder_example.c](https://github.com/xiph/vorbis/blob/master/examples/encoder_example.c). Documentation issues changed in this pull request:
- Entered the range of the floats for the buffer returned by vorbis_analysis_buffer. I actually couldn’t find this in the documentation anywhere, but it’s implied by encoder_example.c and also I found [a mailing list thread](https://lists.xiph.org/pipermail//vorbis/2013-January/thread.html#27682) that seems to confirm it.
- Changed the return values section for vorbis_analysis_blockout and vorbis_bitrate_flushpacket. What it said there didn’t match how it was used in encoder_example.c, nor did it match what the functions did when I looked at the source code, and as I edited the html I noticed it didn’t match what it said at the start of the pages either.

A slightly bigger thing that I didn’t change, but can add on request: The encoding workflow says to output pages, but doesn’t mention anything about doing it through an ogg_stream like encoder_example.c does. I don’t know if there is any other sensible way to output the encoding, but otherwise I think it would be nice for the workflow description to include the ogg_stream stuff. In any case, some additional hint of how to output should be there.