### PR TITLE
Windows: fix syntax error in .def files

### DIFF
--- a/win32/vorbis.def
+++ b/win32/vorbis.def
@@ -1,6 +1,6 @@
 ; vorbis.def
 ; 
-LIBRARY
+LIBRARY vorbis
 EXPORTS
 _floor_P
 _mapping_P

--- a/win32/vorbisenc.def
+++ b/win32/vorbisenc.def
@@ -1,6 +1,6 @@
 ; vorbisenc.def
 ;
-LIBRARY
+LIBRARY vorbisenc
 
 EXPORTS
 vorbis_encode_init

--- a/win32/vorbisfile.def
+++ b/win32/vorbisfile.def
@@ -1,6 +1,6 @@
 ; vorbisfile.def
 ;
-LIBRARY
+LIBRARY vorbisfile
 EXPORTS
 ov_clear
 ov_open


### PR DESCRIPTION
With MSYS2 + mingw-w64, the build of the DLL fails with a syntax error in .def files. LIBRARY should be followed with the library name.